### PR TITLE
Fixed infinite loop in aJson readCommand method. 

### DIFF
--- a/M2XStreamClient/M2XStreamClient.h
+++ b/M2XStreamClient/M2XStreamClient.h
@@ -1863,6 +1863,7 @@ int M2XStreamClient::readCommand(m2x_command_read_callback callback,
             state |= M2X_COMMAND_GOT_NAME;
           }
         }
+	field = field->next;
       }
     }
 


### PR DESCRIPTION
Added line for advancing to the next field while parsing command object.

Ready for Review